### PR TITLE
Fix messed up varargs call in environment

### DIFF
--- a/environment.cpp
+++ b/environment.cpp
@@ -185,8 +185,8 @@ namespace {
 			}
 			va_list ap;
 			va_start(ap, fmt);
-			va_end(ap);
 			vfprintf(stderr, fmt, ap);
+			va_end(ap);
 			fputc('\n', stderr);
 		}
 	}


### PR DESCRIPTION
It looks like the `vfprintf` and `va_end` lines got swapped. This was causing null dereference errors for me.