### PR TITLE
Fix double colon in path to CIncludes in Startup

### DIFF
--- a/etc/Startup
+++ b/etc/Startup
@@ -22,8 +22,8 @@ set -e PIIGSIncludes "{MPW}Interfaces:PIIGSIncludes:"
 set -e PIIGSLibraries "{MPW}Libraries:PIIGSLibraries:"
 
 # MPW Macintosh compilers
-set -e SCIncludes "{ShellDirectory}:Interfaces:CIncludes:"
-set -e CIncludes "{ShellDirectory}:Interfaces:CIncludes:"
+set -e SCIncludes "{ShellDirectory}Interfaces:CIncludes:"
+set -e CIncludes "{ShellDirectory}Interfaces:CIncludes:"
 set -e AIncludes "{ShellDirectory}Interfaces:AIncludes:"
 set -e RIncludes "{ShellDirectory}Interfaces:RIncludes:"
 set -e PInterfaces "{ShellDirectory}Interfaces:PInterfaces:"


### PR DESCRIPTION
Fixes failure to find files in CIncludes, e.g.:

```
### MWCPPC Usage Warning:
# can't locate include directory '/Users/rschmidt/mpw/3.5::Interfaces:CIncludes:'
### MWCPPC Compiler Error:
#	#include <ConditionalMacros.h>
#	                             ^
# the file 'ConditionalMacros.h' cannot be opened
```
